### PR TITLE
Fix timer overflow

### DIFF
--- a/simpleStorage.js
+++ b/simpleStorage.js
@@ -133,7 +133,7 @@
 
         // set next check
         if(nextExpire != Infinity){
-            _ttl_timeout = setTimeout(_handleTTL, nextExpire - curtime);
+            _ttl_timeout = setTimeout(_handleTTL, Math.min(nextExpire - curtime, 0x7FFFFFFF));
         }
 
         // remove expired from TTL list and save changes
@@ -208,7 +208,7 @@
         // schedule next TTL check
         clearTimeout(_ttl_timeout);
         if(_storage && _storage.__simpleStorage_meta && _storage.__simpleStorage_meta.TTL && _storage.__simpleStorage_meta.TTL.keys.length){
-            _ttl_timeout = setTimeout(_handleTTL, Math.max(_storage.__simpleStorage_meta.TTL.expire[_storage.__simpleStorage_meta.TTL.keys[0]] - curtime, 0));
+            _ttl_timeout = setTimeout(_handleTTL, Math.min(Math.max(_storage.__simpleStorage_meta.TTL.expire[_storage.__simpleStorage_meta.TTL.keys[0]] - curtime, 0), 0x7FFFFFFF));
         }
 
         return true;


### PR DESCRIPTION
This pull request fixes an issue where the timer was triggered immediately given a very big timeout, resulting in massive ttl checks in a short time span (at least in chrome).

To give an example of the bug:

``` javascript
function changeSetting(key, value) {
  simpleStorage.set(key, value, {TTL: 180*24*60*60*1000}); // 180 days or around 6 months of storage!
}

changeSetting('foo', 'bar');
```

In chrome, this simple piece of code is enough to make the timer timeout after its set.

There are no unit tests because this fixes an issue with timers and timers aren't tested anyway. This pull request shouldn't change the state of simplestorage anyway...

References: http://stackoverflow.com/questions/3468607/why-does-settimeout-break-for-large-millisecond-delay-values

Edit: and this https://developer.mozilla.org/en/docs/Web/API/window.setTimeout#Minimum.2F_maximum_delay_and_timeout_nesting
