### PR TITLE
Persist metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,22 @@ simpleStorage.canUse()
 
 Returns true if storage is available
 
+## Events
+
+### simpleStorageItemRemoved
+
+Triggered when an item is removed due to TTL timeout
+
+```javascript
+	$(document).on('simpleStorageItemRemoved', function(event) {
+		console.log('key ' + event.originalEvent.detail.key + ' was removed');
+	})
+```
+
+Where
+
+  * **event.originalEvent.detail.key** - the key for the value removed
+
 ## Demo
 
 See demo [here](http://tahvel.info/simpleStorage/example/).

--- a/simpleStorage.js
+++ b/simpleStorage.js
@@ -98,7 +98,6 @@
 			}
 
 			if (source && sourceMeta) {
-				console.log('loading simpleStorage metadata', sourceMeta)
 				_storage_meta = JSON.parse(sourceMeta);
 			} else {
 				// init meta
@@ -197,7 +196,6 @@
 
 				if (!added) {
 					_storage_meta.TTL.expireOrder.push(key);
-					console.log('new key pushed', key, _storage_meta.TTL.expireOrder)
 				}
 			} else {
 				return false;


### PR DESCRIPTION
Features
---

* Persist metadata
Metadata (i.e. TTLs) are now persisted in the browser storage object so they can be re-created at initialization. Once initialized, they are again inspected for expired keys and the appropriate action taken.

* Add event for item expiring
Event `simpleStorageItemRemoved` was added to that is triggered when an item expires from the store. 
**Example:**
```
$(document).on('simpleStorageItemRemoved', function(event){
    console.log('simpleStorage key is expiring', event.originalEvent.detail.key)
})
```

**Notes:**
Updated version to `0.2.0` as this may be incompatible with existing simpleStorage data stores. (Semantic versioning would require updating the major version to 1.)