### PR TITLE
simplify hasKey by using get method

### DIFF
--- a/simpleStorage.js
+++ b/simpleStorage.js
@@ -410,15 +410,7 @@
         },
 
         hasKey: function(key) {
-            if (!_storage) {
-                return false;
-            }
-
-            if (_storage.hasOwnProperty(key) && key !== '__simpleStorage_meta') {
-                return true;
-            }
-
-            return false;
+            return !!this.get(key);
         },
 
         get: function(key) {


### PR DESCRIPTION
`hasKey` is basically same as `get`. We can use `get` in `hasKey` to check if the key exists 